### PR TITLE
Ajustando postgres no docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -10,4 +10,4 @@ DB_PASS = 123456
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://root:123456@localhost:5455/easysell?connect_timeout=300"
+DATABASE_URL="postgresql://root:123456@postgresdb:5432/easysell?connect_timeout=300"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - .:/usr/src/app/
     working_dir: /usr/src/app/
     command: bash -c "npx prisma generate && npm start "
+    networks:
+      - network
   
 
   postgres-compose:
@@ -33,7 +35,9 @@ services:
     ports:
       - "5455:5432"
     networks:
-      - network
+      network:
+        aliases:
+            - postgresdb
   
     
   pgadmin-compose:


### PR DESCRIPTION
- A aplicação não consegue se conectar no banco de dados pois ela não faz parte do mesmo network
- Para se conecta no banco de dados estando no mesmo network você precisaria do ip que poderia mudar a cada execução, para isso adicionei um alias que seria uma espécie de "dominio" local para o postgres 